### PR TITLE
Fix SetFont error caused by incorrect font size db key casing

### DIFF
--- a/Kui_Nameplates/Modules/CastWarnings.lua
+++ b/Kui_Nameplates/Modules/CastWarnings.lua
@@ -136,7 +136,7 @@ end
 ---------------------------------------------------------------------- Create --
 function mod:CreateCastWarnings(msg, frame)
 	-- casting spell name
-	frame.castWarning = frame:CreateFontString(frame.overlay, {size = "spellName", outline = "OUTLINE"})
+	frame.castWarning = frame:CreateFontString(frame.overlay, {size = "spellname", outline = "OUTLINE"})
 	frame.castWarning:Hide()
 	frame.castWarning:SetPoint("BOTTOM", frame.name, "TOP", 0, 1)
 


### PR DESCRIPTION
SetFontSize in Core.lua ln 390 attempts to fetch addon.sizes.font[size] with a wrong entry leading to a SetFontSize call with "spellName" as the size.. Fixed by correcting casing in Modules/CastWarnings.lua.

Error occurs whenever changing any font size in the config gui.

<img width="585" height="353" alt="Untitled" src="https://github.com/user-attachments/assets/7fb8a41b-767a-4331-9a31-7b0dc6d1c9b4" />
